### PR TITLE
JSON Keystore fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,11 @@ To authenticate using a token, add the `TokenAuthenticationHandler` bean to the 
     <bean class="org.jasig.cas.authentication.handler.support.HttpBasedServiceCredentialsAuthenticationHandler"
       p:httpClient-ref="httpClient" />
     <bean class="edu.usf.cims.cas.support.token.authentication.handler.support.TokenAuthenticationHandler"
-      p:encryptionKey="1234567891234567" 
       p:maxDrift="120"
       p:keystore-ref="jsonKeystore" />
   </list>
  </property>
 ```    
-    
-* **encryptionKey**: Encryption key that is shared with the program generating the token (**MUST** be 16 characters)
     
 * **maxDrift**: Number of seconds to allow for clock drift when validating the timestamp of the token.
 
@@ -84,13 +81,12 @@ You'll also need to add `TokenCredentialsToPrincipalResolver` to the list of pri
 </property>
 ```
 
-As well as add two new bean definitions:
+Finally, define the following bean (to load a `keystore.json` file from `/WEB-INF/classes/`):
 
 ```
-<bean class="java.io.File" id="jsonKeystoreFile">
-  <constructor-arg value="/path/to/a/keystore.json" />
-</bean>
-<bean class="edu.clayton.cas.support.token.keystore.JSONKeystore" id="jsonKeystore" />
+<bean class="edu.clayton.cas.support.token.keystore.JSONKeystore"
+      id="jsonKeystore"
+      p:storeFile="classpath:keystore.json" />
 ```
 
 Where a _keystore.json_ file is simply a JSON array of key objects with two properties: _name_ and _data_. For example, the following JSON defines two keys:
@@ -108,7 +104,7 @@ Where a _keystore.json_ file is simply a JSON array of key objects with two prop
 ]
 ```
         
-The _name_ property of a key could be anything. In this module the _name_ field is the value of the "token_service" parameter that a service will provide when requesting authorization. For example, `https://cas.example.com/login?token_service=number_key&auth_token=…` will attempt to use the above "number_key" to decrypt the given "auth_token".
+The _name_ property of a key could be anything. In this module the _name_ field is the value of the "token_service" parameter that a service will provide when requesting authorization. For example, `https://cas.example.com/?token_service=number_key&auth_token=…` will attempt to use the above "number_key" to decrypt the given "auth_token".
         
 ### Configure Attribute Population and Repository
 To convert the profile data received from the decrypted token, configure the `authenticationMetaDataPopulators` property on the `authenticationManager` bean:

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     <junit.version>4.11</junit.version>
     <logback.version>1.0.13</logback.version>
     <slf4j.version>1.7.5</slf4j.version>
+    <commons-cli.version>1.2</commons-cli.version>
   </properties>
   
   <dependencies>
@@ -102,6 +103,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>${commons-cli.version}</version>
     </dependency>
   </dependencies>
   

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,35 @@
   
   <build>
     <plugins>
-      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   

--- a/src/main/java/edu/clayton/cas/support/token/Token.java
+++ b/src/main/java/edu/clayton/cas/support/token/Token.java
@@ -34,14 +34,13 @@ import java.util.Date;
  * {@link edu.clayton.cas.support.token.Token#getGenerated()} or
  * {@link edu.clayton.cas.support.token.Token#getAttributes()} methods are
  * invoked. Thus, it is imperative that
- * {@link Token#setPrimaryKey(edu.clayton.cas.support.token.keystore.Key)}
+ * {@link Token#setKey(edu.clayton.cas.support.token.keystore.Key)}
  * method be invoked prior to accessing either of these properties.</p>
  */
 public class Token {
   private final static Logger log = LoggerFactory.getLogger(Token.class);
 
-  private Key primaryKey;
-  private Key embeddedKey;
+  private Key key;
   private String tokenData;
   private boolean isDecoded = false;
 
@@ -56,15 +55,6 @@ public class Token {
    */
   public Token(String data) {
     this.tokenData = data;
-  }
-
-  /**
-   * Retrieve the encryption key that was embedded in the token.
-   *
-   * @return The {@link Token#embeddedKey}.
-   */
-  public Key getEmbeddedKey() {
-    return this.embeddedKey;
   }
 
   /**
@@ -120,8 +110,8 @@ public class Token {
    *
    * @param key A valid {@link Key} object.
    */
-  public void setPrimaryKey(Key key) {
-    this.primaryKey = key;
+  public void setKey(Key key) {
+    this.key = key;
   }
 
   private void decryptData() throws Exception {
@@ -130,9 +120,9 @@ public class Token {
     try {
       log.debug(
           "Decrypting token with key = `{}`",
-          new String(this.primaryKey.data())
+          new String(this.key.data())
       );
-      SecretKeySpec skey = new SecretKeySpec(this.primaryKey.data(), "AES");
+      SecretKeySpec skey = new SecretKeySpec(this.key.data(), "AES");
       Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
       cipher.init(Cipher.DECRYPT_MODE, skey);
 
@@ -142,7 +132,6 @@ public class Token {
       log.debug(jsonObject.toString());
 
       this.generated = jsonObject.getLong("generated");
-      this.embeddedKey = new Key(jsonObject.getString("api_key"));
       this.attributes = new TokenAttributes(
           jsonObject.getJSONObject("credentials").toString()
       );

--- a/src/main/java/edu/clayton/cas/support/token/keystore/JSONKeystore.java
+++ b/src/main/java/edu/clayton/cas/support/token/keystore/JSONKeystore.java
@@ -90,6 +90,7 @@ public class JSONKeystore implements Keystore {
       for (int i = 0, j = array.length(); i < j; i += 1) {
         JSONObject obj = array.getJSONObject(i);
         Key key = new Key(obj.getString("name"), obj.getString("data"));
+        log.debug("Adding {} key to keystore.", key.name());
         this.addKey(key);
       }
     } catch (FileNotFoundException e) {
@@ -144,11 +145,15 @@ public class JSONKeystore implements Keystore {
   }
 
   /**
-   * Set the instance's keystore file to the given {@link File}.
+   * Set the instance's keystore file to the given {@link File}. This will
+   * also invoke
+   * {@link edu.clayton.cas.support.token.keystore.JSONKeystore#loadStoreFile()}.
+   * Thus, you should be sure that the instance is okay to re-initialize.
    *
    * @param file The JSON file.
    */
   public void setStoreFile(File file) {
-    this.storeFile = storeFile;
+    this.storeFile = file;
+    this.loadStoreFile();
   }
 }

--- a/src/main/java/edu/clayton/cas/support/token/util/Crypto.java
+++ b/src/main/java/edu/clayton/cas/support/token/util/Crypto.java
@@ -1,0 +1,75 @@
+package edu.clayton.cas.support.token.util;
+
+import org.apache.commons.codec.binary.Base64;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+public class Crypto {
+  /**
+   * Returns a {@link Base64} encoded encrypted string.
+   *
+   * @param string The string to encrypt.
+   * @param key The key to use for encryption.
+   * @return The encrypted encoded string.
+   * @throws NoSuchPaddingException
+   * @throws NoSuchAlgorithmException
+   * @throws InvalidKeyException
+   * @throws BadPaddingException
+   * @throws IllegalBlockSizeException
+   */
+  public static String encryptWithKey(String string, String key)
+      throws NoSuchPaddingException,
+      NoSuchAlgorithmException,
+      InvalidKeyException,
+      BadPaddingException,
+      IllegalBlockSizeException
+  {
+    String encryptedString;
+
+    byte[] encryptedStringData;
+    SecretKeySpec skey = new SecretKeySpec(key.getBytes(), "AES");
+    Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
+    cipher.init(Cipher.ENCRYPT_MODE, skey);
+    encryptedStringData = cipher.doFinal(string.getBytes());
+    encryptedString = Base64.encodeBase64String(encryptedStringData);
+
+    return encryptedString;
+  }
+
+  /**
+   * Decrypts a {@link Base64} encoded encrypted string.
+   *
+   * @param string The encoded string to decrypt.
+   * @param key The key to use for decryption.
+   * @return The decrypted string.
+   * @throws NoSuchPaddingException
+   * @throws NoSuchAlgorithmException
+   * @throws InvalidKeyException
+   * @throws BadPaddingException
+   * @throws IllegalBlockSizeException
+   */
+  public static String decryptEncodedStringWithKey(String string, String key)
+      throws NoSuchPaddingException,
+      NoSuchAlgorithmException,
+      InvalidKeyException,
+      BadPaddingException,
+      IllegalBlockSizeException
+  {
+    String decryptedString;
+
+    byte[] decryptedStringData;
+    SecretKeySpec skey = new SecretKeySpec(key.getBytes(), "AES");
+    Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
+    cipher.init(Cipher.DECRYPT_MODE, skey);
+    decryptedStringData = cipher.doFinal(Base64.decodeBase64(string));
+    decryptedString = new String(decryptedStringData);
+
+    return decryptedString;
+  }
+}

--- a/src/main/java/edu/clayton/cas/support/token/util/TokenGenCLI.java
+++ b/src/main/java/edu/clayton/cas/support/token/util/TokenGenCLI.java
@@ -1,0 +1,4 @@
+package edu.clayton.cas.support.token.util;
+
+public class TokenGenCLI {
+}

--- a/src/main/java/edu/clayton/cas/support/token/util/TokenGenCLI.java
+++ b/src/main/java/edu/clayton/cas/support/token/util/TokenGenCLI.java
@@ -1,4 +1,151 @@
 package edu.clayton.cas.support.token.util;
 
+import org.apache.commons.cli.*;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Date;
+
+/**
+ * Provides a simple tool for generating an encrypted token and
+ * a query parameter string.
+ */
 public class TokenGenCLI {
+  static public void main(String[] args) {
+    Options options = TokenGenCLI.buildOptions();
+    HelpFormatter helpFormatter = new HelpFormatter();
+    CommandLineParser parser = new GnuParser();
+
+    try {
+      CommandLine commandLine = parser.parse(options, args);
+
+      String apiKey = commandLine.getOptionValue("service");
+      String key = commandLine.getOptionValue("key");
+      String firstName = commandLine.getOptionValue("fname");
+      String lastName = commandLine.getOptionValue("lname");
+      String email = commandLine.getOptionValue("email");
+      String username = commandLine.getOptionValue("username");
+
+      JSONObject credentials = new JSONObject();
+      credentials.put("firstname", firstName);
+      credentials.put("lastname", lastName);
+      credentials.put("username", username);
+      credentials.put("email", email);
+
+      JSONObject token = new JSONObject();
+      token.put("api_key", apiKey);
+      token.put("generated", (new Date()).getTime());
+      token.put("credentials", credentials);
+
+      String encryptedToken = Crypto.encryptWithKey(token.toString(), key);
+
+      System.out.println("Token:");
+      System.out.println(encryptedToken);
+
+      System.out.println("Query parameters:");
+      System.out.println(
+          String.format(
+              "?username=%s&token_service=%s&auth_token=%s",
+              username,
+              apiKey,
+              URLEncoder.encode(encryptedToken, "UTF-8")
+          )
+      );
+    } catch (MissingOptionException e) {
+     System.out.println("Missing required option(s)!");
+     helpFormatter.printHelp(
+          "\nTokenGenCLI",
+          "This tool builds a JSON token, encrypts it, and prints the result.",
+          options,
+          "",
+          true
+      );
+    } catch (UnrecognizedOptionException e) {
+      System.out.println("Unrecognized option!");
+      helpFormatter.printHelp(
+          "\nTokenGenCLI",
+          "This tool builds a JSON token, encrypts it, and prints the result.",
+          options,
+          "",
+          true
+      );
+    } catch (ParseException e) {
+      e.printStackTrace();
+    } catch (NoSuchPaddingException e) {
+      e.printStackTrace();
+    } catch (NoSuchAlgorithmException e) {
+      e.printStackTrace();
+    } catch (IllegalBlockSizeException e) {
+      e.printStackTrace();
+    } catch (JSONException e) {
+      e.printStackTrace();
+    } catch (BadPaddingException e) {
+      e.printStackTrace();
+    } catch (InvalidKeyException e) {
+      e.printStackTrace();
+    } catch (UnsupportedEncodingException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private static Options buildOptions() {
+    Options options = new Options();
+
+    Option tokenService = OptionBuilder
+        .withArgName("service")
+        .hasArg()
+        .withDescription("set the name of calling service")
+        .isRequired()
+        .create("service");
+    options.addOption(tokenService);
+
+    Option apiKeyData = OptionBuilder
+        .withArgName("key")
+        .hasArg()
+        .withDescription("set the encryption key string")
+        .isRequired()
+        .create("key");
+    options.addOption(apiKeyData);
+
+    Option username = OptionBuilder
+        .withArgName("username")
+        .hasArg()
+        .withDescription("set the username")
+        .isRequired()
+        .create("username");
+    options.addOption(username);
+
+    Option firstName = OptionBuilder
+        .withArgName("fname")
+        .hasArg()
+        .withDescription("set the user's first name")
+        .isRequired()
+        .create("fname");
+    options.addOption(firstName);
+
+    Option lastName = OptionBuilder
+        .withArgName("lname")
+        .hasArg()
+        .withDescription("set the user's last name")
+        .isRequired()
+        .create("lname");
+    options.addOption(lastName);
+
+    Option email = OptionBuilder
+        .withArgName("email")
+        .hasArg()
+        .withDescription("set the user's email")
+        .isRequired()
+        .create("email");
+    options.addOption(email);
+
+    return options;
+  }
 }

--- a/src/main/java/edu/usf/cims/cas/support/token/authentication/handler/support/TokenAuthenticationHandler.java
+++ b/src/main/java/edu/usf/cims/cas/support/token/authentication/handler/support/TokenAuthenticationHandler.java
@@ -25,7 +25,6 @@ import org.jasig.cas.authentication.principal.Credentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.validation.constraints.Size;
 import java.util.Arrays;
 import java.util.Date;
 
@@ -37,10 +36,6 @@ import java.util.Date;
  */
 public final class TokenAuthenticationHandler extends AbstractPreAndPostProcessingAuthenticationHandler {
   private final static Logger log = LoggerFactory.getLogger(TokenAuthenticationHandler.class);
-
-  /** Key used for AES128 encryption **/
-  @Size(min=16, max=16, message="AES key must be 16 characters!")
-  private String encryptionKey;
 
   /** An instance of a {@link edu.clayton.cas.support.token.keystore.Keystore}. **/
   private Keystore keystore;
@@ -100,10 +95,6 @@ public final class TokenAuthenticationHandler extends AbstractPreAndPostProcessi
     }
 
     return result;
-  }
-
-  public final void setEncryptionKey(final String encryptionKey){
-    this.encryptionKey = encryptionKey;
   }
 
   public final void setKeystore(final Keystore keystore) {

--- a/src/main/java/edu/usf/cims/cas/support/token/authentication/handler/support/TokenAuthenticationHandler.java
+++ b/src/main/java/edu/usf/cims/cas/support/token/authentication/handler/support/TokenAuthenticationHandler.java
@@ -25,7 +25,6 @@ import org.jasig.cas.authentication.principal.Credentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.Date;
 
 /**
@@ -62,7 +61,7 @@ public final class TokenAuthenticationHandler extends AbstractPreAndPostProcessi
 
     // Configure the credential's token so that it can be decrypted.
     Token token = credential.getToken();
-    token.setPrimaryKey(apiKey);
+    token.setKey(apiKey);
     credential.setToken(token);
 
     try {
@@ -87,9 +86,7 @@ public final class TokenAuthenticationHandler extends AbstractPreAndPostProcessi
       throw new BadCredentialsAuthenticationException("error.authentication.credentials.bad.token.expired");
     }
 
-    if (attrUsername.equals(credUsername) &&
-        Arrays.equals(apiKey.data(), token.getEmbeddedKey().data()))
-    {
+    if (attrUsername.equals(credUsername)) {
       log.debug("Authentication Success");
       result = true;
     }

--- a/src/test/java/edu/clayton/cas/support/token/TokenTest.java
+++ b/src/test/java/edu/clayton/cas/support/token/TokenTest.java
@@ -52,7 +52,7 @@ public class TokenTest {
     assertNull(token.getAttributes());
     assertEquals((new Date(0L)).getTime(), token.getGenerated());
 
-    token.setPrimaryKey(this.serverKey);
+    token.setKey(this.serverKey);
     TokenAttributes tokenAttributes = token.getAttributes();
 
     assertEquals(this.generatedTime, token.getGenerated());

--- a/src/test/java/edu/clayton/cas/support/token/keystore/JSONKeystoreTest.java
+++ b/src/test/java/edu/clayton/cas/support/token/keystore/JSONKeystoreTest.java
@@ -10,13 +10,14 @@ import java.net.URL;
 import static org.junit.Assert.*;
 
 public class JSONKeystoreTest {
+  private File keystoreFile;
   private JSONKeystore keystore;
 
   @Before
   public void buildStore() throws URISyntaxException {
     URL url = this.getClass().getClassLoader().getResource("testStore.json");
-    File file = new File(url.toURI());
-    this.keystore = new JSONKeystore(file);
+    this.keystoreFile = new File(url.toURI());
+    this.keystore = new JSONKeystore(this.keystoreFile);
   }
 
   @Test
@@ -46,5 +47,21 @@ public class JSONKeystoreTest {
 
     this.keystore.removeKeyNamed("newKey");
     assertNull(this.keystore.getKeyNamed("newKey"));
+  }
+
+  /**
+   * This test simulates Spring adding the keystore file after it has
+   * already created an instance of {@link JSONKeystore}.
+   */
+  @Test
+  public void nullConstructor() {
+    JSONKeystore jsonKeystore = new JSONKeystore(null);
+    jsonKeystore.setStoreFile(this.keystoreFile);
+
+    Key fooKey = jsonKeystore.getKeyNamed("foo");
+
+    assertNotNull(fooKey);
+    assertEquals("foo", fooKey.name());
+    assertTrue(new String(fooKey.data()).equals("123456789012345"));
   }
 }

--- a/src/test/java/edu/usf/cims/cas/support/token/authentication/handler/support/TokenAuthenticationHandlerTest.java
+++ b/src/test/java/edu/usf/cims/cas/support/token/authentication/handler/support/TokenAuthenticationHandlerTest.java
@@ -19,21 +19,27 @@ public class TokenAuthenticationHandlerTest {
       "YieGnGqxysiX2vAhKztLTX+RwBMnwjCpSLXl5+Ja5mDdxfGaA8N+1ZaaNGVffw==";
 
   private TokenAuthenticationHandler handler;
-  private TokenCredentials tokenCredentials;
+  private TokenCredentials validCredentials;
+  private TokenCredentials invalidCredentials;
 
   @Before
   public void setup() {
     this.handler = new TokenAuthenticationHandler();
-    this.tokenCredentials = new TokenCredentials(
+    this.validCredentials = new TokenCredentials(
         "auser",
         this.b64Token,
         "alphabet_key"
+    );
+    this.invalidCredentials = new TokenCredentials(
+        "auser",
+        this.b64Token,
+        "number_key"
     );
   }
 
   @Test
   public void testSupports() {
-    assertTrue(this.handler.supports(tokenCredentials));
+    assertTrue(this.handler.supports(validCredentials));
   }
 
   @Test
@@ -43,10 +49,9 @@ public class TokenAuthenticationHandlerTest {
     JSONKeystore jsonKeystore = new JSONKeystore(keystoreFile);
 
     this.handler.setKeystore(jsonKeystore);
-    this.handler.setEncryptionKey("abcdefghijklmnop");
     this.handler.setMaxDrift(Integer.MAX_VALUE);
 
-    assertTrue(this.handler.doAuthentication(this.tokenCredentials));
+    assertTrue(this.handler.doAuthentication(this.validCredentials));
   }
 
   @Test(expected = BadCredentialsAuthenticationException.class)
@@ -56,9 +61,8 @@ public class TokenAuthenticationHandlerTest {
     JSONKeystore jsonKeystore = new JSONKeystore(keystoreFile);
 
     this.handler.setKeystore(jsonKeystore);
-    this.handler.setEncryptionKey("abcdefghijklmnop");
     this.handler.setMaxDrift(Integer.MAX_VALUE);
 
-    assertFalse(this.handler.doAuthentication(this.tokenCredentials));
+    assertFalse(this.handler.doAuthentication(this.invalidCredentials));
   }
 }


### PR DESCRIPTION
After attempting to add the module to an actual CAS server I found a couple issues. This pull request fixes those issues. It also adds a CLI tool for creating a test token.

Additionally, it generates Javadoc and Sources JARs when packaging for distribution (I needed at least the sources for doing some debugging in the CAS server).
