### PR TITLE
Adds two new features: optional/required attributes and attribute mappin...

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The token is a AES-128 encrypted JSON object:
 
 The _generated_ field is the timestamp in milliseconds, this value is compared against the system time to verify the age of the token.  The _username_ value is also compared to the _username_ request parameter to ensure this token belongs to this user.
 
+All properties of the _credentials_ object will be available to the CAS attribute repository. That is, if you have a property named "ProviderName" in the _credentials_ object, then it will be available under that name for the attribute repository (e.g. `<entry key="CredentialProviderAttribute" value="ProviderName" />`).
+
 ## Adding Token authentication support to CAS
 
 ### Use the Maven Overlay Method for configuring CAS
@@ -104,6 +106,53 @@ Where a _keystore.json_ file is simply a JSON array of key objects with two prop
 The _name_ property of a key could be anything. The _name_ property is matched against the value of the "token_service" parameter that services provide when requesting authorization. For example, `https://cas.example.com/?token_service=number_key&auth_token=…` will attempt to use the above "number_key" to decrypt the given "auth_token".
 
 The _data_ property is the AES128 key that will be used to decrypt the provided token.  The key must be **EXACTLY** 16 characters
+
+### Optional Beans
+
+There are two additional beans that can be defined: `requiredTokenAttributes` and `tokenAttributesMap`. If either of these beans are added, then the `TokenAuthenticationHandler` will need to be adjust accordingly. For example, adding both beans would result in the `TokenAuthenticationHandler` bean being defined like so:
+
+```
+<bean class="edu.usf.cims.cas.support.token.authentication.handler.support.TokenAuthenticationHandler"
+  p:maxDrift="60"
+  p:keystore-ref="jsonKeystore"
+  p:requiredTokenAttributes-ref="requiredTokenAttributes"
+  p:tokenAttributesMap-ref="tokenAttributesMap" />
+```
+
+#### requiredTokenAttributes
+
+This bean defines the attributes that **must** be present on the _credentials_ object of the encrypted token in order for the token to be valid. At a minimum, the _username_ attribute is always required. You can define any other required attributes by adding a `requiredTokenAttributes` bean like so:
+
+```
+<bean id="requiredTokenAttributes" class="java.util.ArrayList">
+  <constructor-arg>
+    <list>
+      <value>sAMAccountName</value>
+      <value>sn</value>
+      <value>givenName</value>
+    </list>
+  </constructor-arg>
+</bean>
+```
+
+#### tokenAttributesMap
+
+This bean defines a mapping from the attributes in the _credentials_ object to the default properties. The default properties are: "username", "firstname", "lastname", and "email". As an example, let's assume you want to provide Active Directory attributes in your token. In that case, you would define the following bean:
+
+```
+<bean id="tokenAttributesMap" class="java.util.HashMap">
+  <constructor-arg>
+    <map>
+      <entry key="username" value="sAMAccountName" />
+      <entry key="firstname" value="givenName" />
+      <entry key="lastname" value="sn" />
+      <entry key="email" value="mail" />
+    </map>
+  </constructor-arg>
+</bean>
+```
+
+It is recommended that you define this bean if you use anything other than the default attributes. However, it is only required if your are defining an alternate property name for "username".
         
 ### Configure Attribute Population and Repository
 To convert the profile data received from the decrypted token, configure the `authenticationMetaDataPopulators` property on the `authenticationManager` bean:
@@ -150,4 +199,4 @@ To define the `tokenAuthAction` bean, add it to `cas-servlet.xml`:
 <bean id="tokenAuthAction" class="edu.usf.cims.cas.support.token.web.flow.TokenAuthAction">
   <property name="centralAuthenticationService" ref="centralAuthenticationService" />
 </bean>
-```
+``

--- a/src/main/java/edu/clayton/cas/support/token/Token.java
+++ b/src/main/java/edu/clayton/cas/support/token/Token.java
@@ -8,6 +8,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 /**
  * <p>A {@linkplain Token} is derived from data received from a client. This
@@ -42,6 +44,8 @@ public class Token {
 
   private long generated;
   private TokenAttributes attributes;
+  private List requiredTokenAttributes;
+  private Map tokenAttributesMap;
 
   /**
    * Initializes a {@linkplain Token} object from a
@@ -49,7 +53,8 @@ public class Token {
    *
    * @param data The data to decode into a {@linkplain Token}.
    */
-  public Token(String data) {
+  public Token(String data)
+  {
     this.tokenData = data;
   }
 
@@ -110,6 +115,14 @@ public class Token {
     this.key = key;
   }
 
+  public void setRequiredTokenAttributes(List requiredTokenAttributes) {
+    this.requiredTokenAttributes = requiredTokenAttributes;
+  }
+
+  public void setTokenAttributesMap(Map tokenAttributesMap) {
+    this.tokenAttributesMap = tokenAttributesMap;
+  }
+
   private void decryptData() throws Exception {
     try {
       log.debug(
@@ -126,7 +139,9 @@ public class Token {
 
       this.generated = jsonObject.getLong("generated");
       this.attributes = new TokenAttributes(
-          jsonObject.getJSONObject("credentials").toString()
+          jsonObject.getJSONObject("credentials").toString(),
+          this.requiredTokenAttributes,
+          this.tokenAttributesMap
       );
       this.isDecoded = true;
 

--- a/src/main/java/edu/clayton/cas/support/token/TokenAttributes.java
+++ b/src/main/java/edu/clayton/cas/support/token/TokenAttributes.java
@@ -6,16 +6,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * Defines the object encoded in a {@link Token}'s "credentials" property.
  */
-public class TokenAttributes {
+public class TokenAttributes extends ConcurrentHashMap<String, Object> {
   private final static Logger log = LoggerFactory.getLogger(TokenAttributes.class);
 
-  private String username;
-  private String firstName;
-  private String lastName;
-  private String email;
+  private List<String> requiredTokenAttributes;
+  private Map<String, String> tokenAttributesMap;
 
   /**
    * Initialize a {@linkplain TokenAttributes} object from a JSON
@@ -24,50 +26,154 @@ public class TokenAttributes {
    * @param data The JSON encoded string of data.
    */
   public TokenAttributes(String data) {
-    Assert.notNull(data);
-    JSONObject jsonObject;
+    this(data, null, null);
+  }
 
+  /**
+   * Initialize a {@linkplain TokenAttributes} object from a JSON
+   * encoded string. Also, set the required attributes list and the
+   * attributes mapping.
+   *
+   * @param data The JSON encoded string of data.
+   * @param requiredTokenAttributes A list of required attribute names.
+   * @param tokenAttributesMap A map that maps incoming attribute names to properties of this object.
+   */
+  public TokenAttributes(String data, List requiredTokenAttributes, Map tokenAttributesMap)
+  {
+    Assert.notNull(data);
+    this.requiredTokenAttributes = requiredTokenAttributes;
+    this.tokenAttributesMap = tokenAttributesMap;
+
+    JSONObject jsonObject;
     try {
       jsonObject= new JSONObject(data);
-      this.username = jsonObject.getString("username");
-      this.firstName = jsonObject.getString("firstname");
-      this.lastName = jsonObject.getString("lastname");
-      this.email = jsonObject.getString("email");
+
+      String[] keys = JSONObject.getNames(jsonObject);
+
+      for (String k : keys) {
+        this.put(k, jsonObject.get(k));
+      }
+
     } catch (JSONException e) {
       log.error("Could not parse TokenAttributes data!");
       log.debug(e.toString());
     }
   }
 
+  /**
+   * Defines a list of attributes that are required to be present in the
+   * "credentials" object of the decrypted {@link Token}. A call to
+   * {@link edu.clayton.cas.support.token.TokenAttributes#isValid()} must
+   * be made to determine if the attributes defined by this list are present
+   * on the {@linkplain TokenAttributes} instance.
+   *
+   * @param attributes A {@link List} of required attributes.
+   */
+  public void setRequiredTokenAttributes(List<String> attributes) {
+    this.requiredTokenAttributes = attributes;
+  }
+
+  /**
+   * <p>Defines a mapping of attribute names in the incoming "credentials" object
+   * to properties of a {@link TokenAttributes} instance. The map structure
+   * should be such that the key name is the {@linkplain TokenAttributes}
+   * property name, and the value the key name of the credentials object.
+   * For example:</p>
+   *
+   * <pre>
+   *   {
+   *     "firstName" : "fname",
+   *     "lastName" : "lname",
+   *     "email" : "email",
+   *     "username" : "uname"
+   *   }
+   * </pre>
+   *
+   * <p>Note that all properties of a {@linkplain TokenAttributes} instance
+   * are present in the mapping. You should do this whenever you define
+   * an attribute mapping.</p>
+   *
+   * @param attributesMap A {@link Map} of attribute names.
+   */
+  public void setTokenAttributesMap(Map<String, String> attributesMap) {
+    this.tokenAttributesMap = attributesMap;
+  }
+
+  /**
+   * Used to determine if the instance contains all of the
+   * {@link TokenAttributes#requiredTokenAttributes}. If any of the
+   * required attributes are missing, this will return {@code false}.
+   *
+   * @return {@code true} if all required attributes are present
+   */
+  public boolean isValid() {
+    boolean result = true;
+
+    // The username attribute will always be required.
+    result = (this.getUsername() != null);
+
+    if (result == true && this.requiredTokenAttributes != null) {
+      for (String attr : this.requiredTokenAttributes) {
+        if (this.get(attr) == null) {
+          result = false;
+          break;
+        }
+      }
+    }
+
+    return result;
+  }
+
   public String getEmail() {
-    return this.email;
+    return (String) this.get(this.lookupAttributeName("email"));
   }
 
   public void setEmail(String email) {
-    this.email = email;
+    this.put(this.lookupAttributeName("email"), email);
   }
 
   public String getFirstName() {
-    return this.firstName;
+    return (String) this.get(this.lookupAttributeName("firstName"));
   }
 
   public void setFirstName(String firstName) {
-    this.firstName = firstName;
+    this.put(this.lookupAttributeName("firstName"), firstName);
   }
 
   public String getLastName() {
-    return this.lastName;
+    return (String) this.get(this.lookupAttributeName("lastName"));
   }
 
   public void setLastName(String lastName) {
-    this.lastName = lastName;
+    this.put(this.lookupAttributeName("lastName"), lastName);
   }
 
   public String getUsername() {
-    return this.username;
+    return (String) this.get(this.lookupAttributeName("username"));
   }
 
   public void setUsername(String username) {
-    this.username = username;
+    this.put(this.lookupAttributeName("username"), username);
+  }
+
+  /**
+   * Used to lookup the name of an attribute based on whether or not
+   * there is an alternate mapping supplied by
+   * {@link TokenAttributes#tokenAttributesMap}.
+   *
+   * @param attribute The name of the {@linkplain TokenAttributes} property to lookup.
+   * @return The mapped name, or the passed in name.
+   */
+  private String lookupAttributeName(String attribute) {
+    // .toLowerCase() because the original methods were not camel cased.
+    String result = attribute.toLowerCase();
+    String tmp;
+
+    if (this.tokenAttributesMap != null) {
+      tmp = this.tokenAttributesMap.get(attribute);
+      result = (tmp == null) ? result : tmp;
+    }
+
+    return result;
   }
 }

--- a/src/main/java/edu/usf/cims/cas/support/token/authentication/handler/support/TokenAuthenticationHandler.java
+++ b/src/main/java/edu/usf/cims/cas/support/token/authentication/handler/support/TokenAuthenticationHandler.java
@@ -26,6 +26,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This handler authenticates token credentials 
@@ -38,6 +40,12 @@ public final class TokenAuthenticationHandler extends AbstractPreAndPostProcessi
 
   /** An instance of a {@link edu.clayton.cas.support.token.keystore.Keystore}. **/
   private Keystore keystore;
+
+  /** A list of required attributes that will be passed along to the {@link edu.clayton.cas.support.token.TokenAttributes} instance. **/
+  private List requiredTokenAttributes;
+
+  /** A map of attribute names to {@link edu.clayton.cas.support.token.TokenAttributes} properties that will be passed along. **/
+  private Map tokenAttributesMap;
 
   /* Maximum amount of time (before or after current time) that the 'generated' parameter 
    * in the supplied token can differ from the server */
@@ -62,6 +70,8 @@ public final class TokenAuthenticationHandler extends AbstractPreAndPostProcessi
     // Configure the credential's token so that it can be decrypted.
     Token token = credential.getToken();
     token.setKey(apiKey);
+    token.setRequiredTokenAttributes(this.requiredTokenAttributes);
+    token.setTokenAttributesMap(this.tokenAttributesMap);
     credential.setToken(token);
 
     try {
@@ -71,8 +81,10 @@ public final class TokenAuthenticationHandler extends AbstractPreAndPostProcessi
       throw new BadCredentialsAuthenticationException("error.authentication.credentials.bad.token.key");
     }
 
+    // This username was given in the request URL.
     String credUsername = credential.getUsername();
-    String attrUsername = (String) credential.getUserAttributes().get("PreferredUsername");
+    // This username is from the decrypted token.
+    String attrUsername = credential.getToken().getAttributes().getUsername();
 
     log.debug("Got username from token : {}", credUsername);
 
@@ -103,5 +115,12 @@ public final class TokenAuthenticationHandler extends AbstractPreAndPostProcessi
   public final void setMaxDrift(final int maxDrift){
     this.maxDrift = maxDrift;
   }
-    
+
+  public final void setRequiredTokenAttributes(final List requiredTokenAttributes) {
+    this.requiredTokenAttributes = requiredTokenAttributes;
+  }
+
+  public final void setTokenAttributesMap(final Map tokenAttributesMap) {
+    this.tokenAttributesMap = tokenAttributesMap;
+  }
 }

--- a/src/main/java/edu/usf/cims/cas/support/token/authentication/principal/TokenCredentials.java
+++ b/src/main/java/edu/usf/cims/cas/support/token/authentication/principal/TokenCredentials.java
@@ -21,7 +21,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -32,7 +31,7 @@ import java.util.Map;
  */
 public final class TokenCredentials implements Credentials {
     
-  private static final long serialVersionUID = 2749515041385101769L;
+  private static final long serialVersionUID = 2749515041385101770L;
 
   private static final Logger logger = LoggerFactory.getLogger(TokenCredentials.class);
 
@@ -85,16 +84,7 @@ public final class TokenCredentials implements Credentials {
    */
   public void setUserAttributes(TokenAttributes userProfile) {
     Assert.notNull(userProfile);
-    this.userAttributes = new HashMap<String, Object>();
-    this.userAttributes.put("ProviderName", "UsfNetId");
-    this.userAttributes.put(
-        "DisplayName",
-        String.format("%s %s", userProfile.getFirstName(), userProfile.getLastName())
-    );
-    this.userAttributes.put("FamilyName", userProfile.getLastName());
-    this.userAttributes.put("GivenName", userProfile.getFirstName());
-    this.userAttributes.put("Email", userProfile.getEmail());
-    this.userAttributes.put("PreferredUsername", userProfile.getUsername());
+    this.userAttributes = userProfile;
   }
 
   public String toString() {

--- a/src/test/java/edu/clayton/cas/support/token/TokenAttributesTest.java
+++ b/src/test/java/edu/clayton/cas/support/token/TokenAttributesTest.java
@@ -1,20 +1,26 @@
 package edu.clayton.cas.support.token;
 
-import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class TokenAttributesTest {
+  private static final Logger log = LoggerFactory.getLogger(TokenAttributesTest.class);
+
   private String json;
 
-  @Before
-  public void readJSON() throws Exception {
-    URL url = this.getClass().getClassLoader().getResource("testTokenAttributes.json");
+  private void readJSON(String fileName) throws Exception {
+    URL url = this.getClass().getClassLoader().getResource(fileName);
     File file = new File(url.toURI());
     FileInputStream fis = new FileInputStream(file);
     byte[] buffer = new byte[(int)file.length()];
@@ -26,12 +32,60 @@ public class TokenAttributesTest {
   }
 
   @Test
-  public void wholeShebang() {
+  public void standardAttributes() throws Exception {
+    log.info("Checking a standard attributes object");
+
+    this.readJSON("testTokenAttributes.json");
     TokenAttributes tokenAttributes = new TokenAttributes(this.json);
 
     assertTrue("auser".equals(tokenAttributes.getUsername()));
     assertTrue("Foo".equals(tokenAttributes.getFirstName()));
     assertTrue("Bar".equals(tokenAttributes.getLastName()));
     assertTrue("foobar@example.com".equals(tokenAttributes.getEmail()));
+  }
+
+  @Test
+  public void alternateAttributes() throws Exception {
+    log.info("Checking an alternate attributes object");
+
+    // An Active Directory style attributes map.
+    this.readJSON("testAlternateTokenAttributes.json");
+    TokenAttributes tokenAttributes = new TokenAttributes(this.json);
+
+    ArrayList<String> requiredAttributes = new ArrayList<String>(2);
+    requiredAttributes.add("sAMAccountName");
+    requiredAttributes.add("mail");
+    tokenAttributes.setRequiredTokenAttributes(requiredAttributes);
+
+    log.info("Verifying required attributes are missing");
+    assertFalse(tokenAttributes.isValid());
+
+    log.info("Setting an attributes mapping");
+    HashMap<String, String> attributesMap = new HashMap<String, String>(4);
+    attributesMap.put("username", "sAMAccountName");
+    attributesMap.put("firstName", "givenName");
+    attributesMap.put("lastName", "sn");
+    attributesMap.put("email", "mail");
+    tokenAttributes.setTokenAttributesMap(attributesMap);
+
+    log.info("Verifying required attributes are now present");
+    assertTrue(tokenAttributes.isValid());
+
+    log.info("Verifying attributes are set correctly");
+    assertTrue("auser".equals(tokenAttributes.getUsername()));
+    assertTrue("Foo".equals(tokenAttributes.getFirstName()));
+    assertTrue("Bar".equals(tokenAttributes.getLastName()));
+    assertTrue("foobar@example.com".equals(tokenAttributes.getEmail()));
+  }
+
+  @Test
+  public void testUsernameOnlyAttributeList() throws Exception {
+    log.info("Checking an username only attributes object");
+
+    this.readJSON("testUsernameOnlyTokenAttributes.json");
+    TokenAttributes tokenAttributes = new TokenAttributes(this.json);
+
+    assertTrue("auser".equals(tokenAttributes.getUsername()));
+    assertNull(tokenAttributes.getFirstName());
   }
 }

--- a/src/test/java/edu/clayton/cas/support/token/TokenTest.java
+++ b/src/test/java/edu/clayton/cas/support/token/TokenTest.java
@@ -55,5 +55,8 @@ public class TokenTest {
     assertTrue("Foo".equals(tokenAttributes.getFirstName()));
     assertTrue("Bar".equals(tokenAttributes.getLastName()));
     assertTrue("foobar@example.com".equals(tokenAttributes.getEmail()));
+
+    tokenAttributes.put("answer", 42);
+    assertEquals(42, tokenAttributes.get("answer"));
   }
 }

--- a/src/test/resources/testAlternateTokenAttributes.json
+++ b/src/test/resources/testAlternateTokenAttributes.json
@@ -1,0 +1,6 @@
+{
+  "sAMAccountName" : "auser",
+  "givenName" : "Foo",
+  "sn" : "Bar",
+  "mail" : "foobar@example.com"
+}

--- a/src/test/resources/testUsernameOnlyTokenAttributes.json
+++ b/src/test/resources/testUsernameOnlyTokenAttributes.json
@@ -1,0 +1,3 @@
+{
+  "username" : "auser"
+}


### PR DESCRIPTION
...g

Both of the features complement each other. Thus the single pull request.

The first feature adds the ability to define which attributes are
required in the `credentials` object of the encrypted JSON. This has
the side effect of also allowing any attributes to be passed in via
the `credentials` object such that those attributes will be available
to the CAS attribute repository (as they are named in the `credentials`
object). This resolves bug #1.

The second feature adds the ability to map property names of the
`credentials` object to the properties of a TokenAttributes instance.
Thus, the `credentials` object could have a property named
"sAMAccountName" and this feature can be used to map that to the
"username" property of the TokenAttributes instance for the request.
The only time this mapping is required is when the username property
is renamed.

When implementing this add-on I discovered that I could not map the
attributes for services using this add-on to the properties we use
from our primary authentication source (Active Directory). So this
is my solution to that problem.

Note, this changes the point at which your "ProviderName" ("UsfNetId")
would be added to the attributes list. If this patch is accepted, you
would have to add that attribute in the JSON you send to the CAS server.
