### PR TITLE
Adds missing check for valid attributes

### DIFF
--- a/src/main/java/edu/usf/cims/cas/support/token/authentication/handler/support/TokenAuthenticationHandler.java
+++ b/src/main/java/edu/usf/cims/cas/support/token/authentication/handler/support/TokenAuthenticationHandler.java
@@ -81,6 +81,11 @@ public final class TokenAuthenticationHandler extends AbstractPreAndPostProcessi
       throw new BadCredentialsAuthenticationException("error.authentication.credentials.bad.token.key");
     }
 
+    if (!token.getAttributes().isValid()) {
+      log.warn("Invalid token attributes detected.");
+      throw new BadCredentialsAuthenticationException("error.authentication.credentials.missing.required.attributes");
+    }
+
     // This username was given in the request URL.
     String credUsername = credential.getUsername();
     // This username is from the decrypted token.


### PR DESCRIPTION
It seems that I forgot to add a check to make sure the decrypted
token has all of the specified required attributes. This commit
fixes that oversight.
